### PR TITLE
Fix overlapping exported config

### DIFF
--- a/config
+++ b/config
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 export RABBITMQ_IMAGE=${RABBITMQ_IMAGE:="rabbitmq"}
 export RABBITMQ_IMAGE_VERSION=${RABBITMQ_IMAGE_VERSION:="3.5.4-management"}
-export RABBITMQ_ROOT=/var/lib/dokku/services/rabbitmq
+export RABBITMQ_ROOT=${RABBITMQ_ROOT:="/var/lib/dokku/services/rabbitmq"}
 
 export PLUGIN_COMMAND_PREFIX="rabbitmq"
-export PLUGIN_DATA_ROOT=${PLUGIN_DATA_ROOT:="$RABBITMQ_ROOT"}
+export PLUGIN_DATA_ROOT=$RABBITMQ_ROOT
 export PLUGIN_DATASTORE_PORTS=(5672 4369 35197 15672)
 export PLUGIN_DEFAULT_ALIAS="RABBITMQ"
 export PLUGIN_IMAGE=$RABBITMQ_IMAGE

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -8,7 +8,8 @@ export PLUGIN_PATH="$DOKKU_ROOT/plugins"
 export PLUGIN_ENABLED_PATH="$PLUGIN_PATH"
 export PLUGIN_AVAILABLE_PATH="$PLUGIN_PATH"
 export PLUGIN_CORE_AVAILABLE_PATH="$PLUGIN_PATH"
-export PLUGIN_DATA_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fixtures"
+export RABBITMQ_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/fixtures"
+export PLUGIN_DATA_ROOT="$RABBITMQ_ROOT"
 
 mkdir -p "$PLUGIN_DATA_ROOT"
 rm -rf "${PLUGIN_DATA_ROOT:?}"/*


### PR DESCRIPTION
If using multiple official dokku datastorage plugins, it is possible to get into a case where the `PLUGIN_DATA_ROOT` would be set incorrectly for other plugins.

Refs dokku/dokku-redis#20